### PR TITLE
feat(i18n): auto-select regional language on first visit + wire SSR pre-translation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6330,26 +6330,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001762",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
-      "integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
-    },
     "node_modules/chalk": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",

--- a/src/app/[slug]/page.js
+++ b/src/app/[slug]/page.js
@@ -1,10 +1,12 @@
 //export const dynamic = "force-dynamic";
 import PrivacyPolicy from "@/components/features/privacy/PrivacyPolicy";
 import { notFound } from "next/navigation";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchData(type) {
+async function fetchData(type, locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/policies?type=${type}`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/policies?type=${type}`, locale), {
       cache: "no-store", // Ensure fresh data
       // cache: "force-cache",
       // next: { revalidate: 60 },
@@ -37,7 +39,8 @@ async function fetchData(type) {
 
 export default async function PolicyPage({ params }) {
   const { slug } = await params;
-  const { content, error } = await fetchData(slug);
+  const locale = await getServerLocale();
+  const { content, error } = await fetchData(slug, locale);
 
   if (error || !content) {
     notFound();

--- a/src/app/about-indel-money/page.js
+++ b/src/app/about-indel-money/page.js
@@ -17,10 +17,12 @@ import MobAccolades from "../../components/features/about/MobAccolades";
 import MobIndelValuesInfo from "../../components/features/about/MobIndelValuesInfo";
 import MobInvestors from "../../components/features/about/MobInvestorsInfo";
 import MobLifeIndel from "../../components/features/about/MobLifeIndelInfo";
+import { getServerLocale } from "../../lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "../../lib/locale/localizedUrl";
 
-async function fetchAboutData() {
+async function fetchAboutData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/about`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/about`, locale), {
       // cache: "no-store",
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -36,9 +38,9 @@ async function fetchAboutData() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=about`);
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=about`, locale));
     const result = await response.json();
     const meta = result.data;
 
@@ -113,7 +115,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -125,7 +128,8 @@ export async function generateMetadata() {
 }
 
 export default async function About() {
-  const { data, error } = await fetchAboutData();
+  const locale = await getServerLocale();
+  const { data, error } = await fetchAboutData(locale);
 
   if (!data) {
     return <div>Failed to fetch about data</div>;

--- a/src/app/annual-reports/page.js
+++ b/src/app/annual-reports/page.js
@@ -3,10 +3,12 @@ import React from "react";
 import Report from "../../components/features/investors/Report";
 
 import api from "../../lib/api/axios";
+import { getServerLocale } from "../../lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "../../lib/locale/localizedUrl";
 
-async function fetchReportData() {
+async function fetchReportData(locale) {
   try {
-    const response = await api.get(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/investors/report`, {
+    const response = await api.get(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/investors/report`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -38,7 +40,8 @@ async function fetchReportData() {
 }
 
 export default async function report() {
-  const { content, reports, returns, error } = await fetchReportData();
+  const locale = await getServerLocale();
+  const { content, reports, returns, error } = await fetchReportData(locale);
 
   if (!reports && !returns) {
     return <div>Failed to fetch report data</div>;

--- a/src/app/award/page.js
+++ b/src/app/award/page.js
@@ -2,10 +2,12 @@
 import AwardClient from "@/pages/AwardClient";
 import NoContents from "@/components/NoContents";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchData() {
+async function fetchData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/awards`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/awards`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -27,9 +29,9 @@ async function fetchData() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=award`);
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=award`, locale));
     const result = await response.json();
     const meta = result.data;
 
@@ -104,7 +106,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -116,7 +119,8 @@ export async function generateMetadata() {
 }
 
 export default async function Award() {
-  const { contents, awards, sliderItems, error } = await fetchData();
+  const locale = await getServerLocale();
+  const { contents, awards, sliderItems, error } = await fetchData(locale);
 
   if (!contents) {
     return <NoContents />;

--- a/src/app/blog/[slug]/page.js
+++ b/src/app/blog/[slug]/page.js
@@ -2,11 +2,13 @@
 import BlogDetail from "@/components/features/blog/BlogDetail";
 import RecentBlog from "@/components/features/blog/RecentBlog";
 import { notFound } from "next/navigation";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
 // Fetch blog data for a specific post
-async function fetchBlogData(slug) {
+async function fetchBlogData(slug, locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/blogs/${slug}`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/blogs/${slug}`, locale), {
       // next: { revalidate: 60 },
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -66,9 +68,9 @@ const defaultMetadata = (slug = "") => ({
   },
 });
 
-async function getMetaData(slug) {
+async function getMetaData(slug, locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta-slug?page=blogItem&slug=${slug}`);
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta-slug?page=blogItem&slug=${slug}`, locale));
     const result = await response.json();
     const meta = result.data;
 
@@ -93,7 +95,8 @@ async function getMetaData(slug) {
 // Generate dynamic metadata
 export async function generateMetadata({ params }) {
   const { slug } = await params;
-  const { meta, error } = await getMetaData(slug);
+  const locale = await getServerLocale();
+  const { meta, error } = await getMetaData(slug, locale);
 
   if (!meta || error) {
     return defaultMetadata(slug);
@@ -130,7 +133,8 @@ export async function generateMetadata({ params }) {
 
 export default async function Blog({ params }) {
   const { slug } = await params;
-  const { data: blogData, recentBlogs, title, error: blogError } = await fetchBlogData(slug);
+  const locale = await getServerLocale();
+  const { data: blogData, recentBlogs, title, error: blogError } = await fetchBlogData(slug, locale);
 
   // Handle error state for blog data
   if (blogError || !blogData) {

--- a/src/app/blog/page.js
+++ b/src/app/blog/page.js
@@ -2,8 +2,10 @@
 import Script from "next/script";
 import LatestBlogs from "@/pages/LatestBlogs";
 import AllBlogsPage from "@/pages/AllBlogs";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function getMetaData() {
+async function getMetaData(locale) {
   const defaultMeta = {
     title: "Blogs | My Website",
     description: "Explore insights, stories, and updates from Indel.",
@@ -11,7 +13,7 @@ async function getMetaData() {
   };
 
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=blog`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=blog`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
     });
@@ -40,7 +42,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords } = await getMetaData(locale);
 
   return {
     title,

--- a/src/app/board-of-directors/page.js
+++ b/src/app/board-of-directors/page.js
@@ -1,10 +1,12 @@
 //export const dynamic = "force-dynamic";
 import ManagementTeam from "@/components/features/management-team/ManagementTeam";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchManagementData() {
+async function fetchManagementData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/directors`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/directors`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -20,9 +22,9 @@ async function fetchManagementData() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=directors`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=directors`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
     });
@@ -100,7 +102,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -112,7 +115,8 @@ export async function generateMetadata() {
 }
 
 export default async function ManagementTeamPage() {
-  const { data, error } = await fetchManagementData();
+  const locale = await getServerLocale();
+  const { data, error } = await fetchManagementData(locale);
 
   if (!data) {
     return <div>Failed to fetch directors data</div>;

--- a/src/app/branch-locator/page.js
+++ b/src/app/branch-locator/page.js
@@ -1,10 +1,12 @@
 //export const dynamic = "force-dynamic";
 import BranchLocator from "../../components/features/home/BranchLocator";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchData() {
+async function fetchData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/branch-locator`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/branch-locator`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -30,9 +32,9 @@ async function fetchData() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=branchlocator`);
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=branchlocator`, locale));
     const result = await response.json();
     const meta = result.data;
 
@@ -107,7 +109,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -119,7 +122,8 @@ export async function generateMetadata() {
 }
 
 export default async function Branch() {
-  const { branchData, error } = await fetchData();
+  const locale = await getServerLocale();
+  const { branchData, error } = await fetchData(locale);
 
   if (!branchData || error) {
     return <div>{"No data"}</div>;

--- a/src/app/career-list/page.js
+++ b/src/app/career-list/page.js
@@ -2,10 +2,12 @@
 import ActiveJobsBanner from "@/components/features/career/ActiveJobsBanner";
 import ActiveJobsInfo from "@/components/features/career/ActiveJobsInfo";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=listings`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=listings`, locale), {
       cache: "force-cache",
       next: { revalidate: 60 },
     });
@@ -83,7 +85,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,

--- a/src/app/career/page.js
+++ b/src/app/career/page.js
@@ -8,10 +8,12 @@ import MakeYourMove from "@/components/features/career/MakeYourMove";
 import BenefitsEmployee from "@/components/features/career/BenefitsEmployee";
 import MobBenefitsEmployee from "@/components/features/career/MobBenefitsEmployee";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchData() {
+async function fetchData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/career`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/career`, locale), {
       cache: "no-store", // Ensure fresh data
       // cache: "force-cache",
       // next: { revalidate: 600 },
@@ -63,9 +65,9 @@ async function fetchData() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=career`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=career`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
     });
@@ -143,7 +145,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -155,7 +158,8 @@ export async function generateMetadata() {
 }
 
 export default async function Career() {
-  const { contents, banners, benefits, awards, gallery, testimonials, states, jobs, error } = await fetchData();
+  const locale = await getServerLocale();
+  const { contents, banners, benefits, awards, gallery, testimonials, states, jobs, error } = await fetchData(locale);
 
   if (error) {
     return <div>{error}</div>;

--- a/src/app/consumer-durable-loans/page.js
+++ b/src/app/consumer-durable-loans/page.js
@@ -2,13 +2,15 @@
 import { defaultMeta } from "@/constants/constants";
 import { headers } from "next/headers";
 import CDLoanClient from "../../pages/CDLoanClient";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
 function isMobileDevice(userAgent) {
   return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(userAgent);
 }
-async function fetchData() {
+async function fetchData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/cd-loan`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/cd-loan`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -31,9 +33,9 @@ async function fetchData() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=cdloan`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=cdloan`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
     });
@@ -111,7 +113,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -123,7 +126,8 @@ export async function generateMetadata() {
 }
 
 export default async function CDLoan() {
-  const { contents, benfits, products, faqs, error } = await fetchData();
+  const locale = await getServerLocale();
+  const { contents, benfits, products, faqs, error } = await fetchData(locale);
 
   const headersList = await headers(); // ✅ await here
   const userAgent = headersList.get("user-agent") || "";

--- a/src/app/contact/page.js
+++ b/src/app/contact/page.js
@@ -5,10 +5,12 @@ import WriteIntel from "@/components/features/contact/WriteIntel";
 import ContactFaq from "@/components/features/contact/ContactFaq";
 import { defaultMeta } from "@/constants/constants";
 import BranchLocator from "../../components/features/home/BranchLocator";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchContactsData() {
+async function fetchContactsData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/contacts`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/contacts`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -36,9 +38,9 @@ async function fetchContactsData() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=contact`);
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=contact`, locale));
     const result = await response.json();
     const meta = result.data;
 
@@ -113,7 +115,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -125,7 +128,8 @@ export async function generateMetadata() {
 }
 
 export default async function Contact() {
-  const { contents, faqs, officeContacts, branchLocatorData, error } = await fetchContactsData();
+  const locale = await getServerLocale();
+  const { contents, faqs, officeContacts, branchLocatorData, error } = await fetchContactsData(locale);
 
   if (!contents || !faqs || !officeContacts) {
     return <div>Failed to fetch contact data</div>;

--- a/src/app/corporate-governance/page.js
+++ b/src/app/corporate-governance/page.js
@@ -1,9 +1,11 @@
 //export const dynamic = "force-dynamic";
 import GoverenanceInfo from "../../components/features/investors/GoverenanceInfo";
+import { getServerLocale } from "../../lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "../../lib/locale/localizedUrl";
 
-async function fetchCorporateGoverneceData() {
+async function fetchCorporateGoverneceData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/investors/corporate-governance`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/investors/corporate-governance`, locale), {
       // cache: 'no-store', // or 'force-cache' depending on your needs
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -30,7 +32,8 @@ async function fetchCorporateGoverneceData() {
 }
 
 export default async function Goverenance() {
-  const { contents, pdfItems } = await fetchCorporateGoverneceData();
+  const locale = await getServerLocale();
+  const { contents, pdfItems } = await fetchCorporateGoverneceData(locale);
 
   if (!contents && !pdfItems) {
     return <div>Failed to fetch report data</div>;

--- a/src/app/credit-rating/page.js
+++ b/src/app/credit-rating/page.js
@@ -2,10 +2,12 @@
 import React from "react";
 import CreditRatings from "../../components/features/investors/CreditRatings";
 import { notFound } from "next/navigation";
+import { getServerLocale } from "../../lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "../../lib/locale/localizedUrl";
 
-async function fetchCreditRatingsData() {
+async function fetchCreditRatingsData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/investors/credit-ratings`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/investors/credit-ratings`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -22,7 +24,8 @@ async function fetchCreditRatingsData() {
 }
 
 export default async function QuarterlyReports() {
-  const { content, reports, error } = await fetchCreditRatingsData();
+  const locale = await getServerLocale();
+  const { content, reports, error } = await fetchCreditRatingsData(locale);
 
   if (!reports) {
     notFound();

--- a/src/app/csr/[slug]/page.js
+++ b/src/app/csr/[slug]/page.js
@@ -2,6 +2,8 @@ import dynamic from "next/dynamic";
 import CsrDetail from "@/components/features/csr/BlogDetail";
 import RecentCsr from "@/components/features/csr/RecentCSR";
 import { notFound } from "next/navigation";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
 const LatestUpdates = dynamic(() => import("@/components/features/home/LatestUpdates"), {
   loading: () => <div>Loading slider...</div>,
@@ -11,9 +13,9 @@ const MobLatestUpdates = dynamic(() => import("@/components/features/csr/MobLate
 });
 
 // Fetch single CSR data
-async function fetchCsrData(slug) {
+async function fetchCsrData(slug, locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/csr/${slug}`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/csr/${slug}`, locale), {
       // next: { revalidate: 60 },
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -40,9 +42,9 @@ async function fetchCsrData(slug) {
 }
 
 // Fetch recent CSR posts
-async function fetchRecentCsrs(slug) {
+async function fetchRecentCsrs(slug, locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/csr?limit=3`, {});
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/csr?limit=3`, locale), {});
     if (!response.ok) {
       throw new Error(`HTTP error! Status: ${response.status}`);
     }
@@ -60,7 +62,8 @@ async function fetchRecentCsrs(slug) {
 // Generate metadata for CSR
 export async function generateMetadata({ params }) {
   const { slug } = params;
-  const { content: data, error } = await fetchCsrData(slug);
+  const locale = await getServerLocale();
+  const { content: data, error } = await fetchCsrData(slug, locale);
 
   if (error || !data) {
     return {
@@ -127,8 +130,9 @@ export async function generateMetadata({ params }) {
 // Main component for CSR detail page
 export default async function CSRDetailPage({ params }) {
   const { slug } = params;
-  const { content: csrData, error: csrError } = await fetchCsrData(slug);
-  const { data: recentCsrs, error: recentError } = await fetchRecentCsrs(slug);
+  const locale = await getServerLocale();
+  const { content: csrData, error: csrError } = await fetchCsrData(slug, locale);
+  const { data: recentCsrs, error: recentError } = await fetchRecentCsrs(slug, locale);
 
   if (csrError || !csrData) {
     notFound();

--- a/src/app/csr/page.js
+++ b/src/app/csr/page.js
@@ -8,10 +8,12 @@ import {
 } from "@/components/ui/pagination";
 import MobLatestUpdates from "../../components/features/home/MobLatestUpdates";
 import LatestUpdates from "../../components/features/home/LatestUpdates";
+import { getServerLocale } from "../../lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "../../lib/locale/localizedUrl";
 
-async function fetchCsrData(page = 1, limit = 10) {
+async function fetchCsrData(page = 1, limit = 10, locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/csr?page=${page}&limit=${limit}`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/csr?page=${page}&limit=${limit}`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -48,7 +50,8 @@ async function fetchCsrData(page = 1, limit = 10) {
 
 export async function generateMetadata({ params }) {
   const page = parseInt(params?.page) || 1;
-  const { content, error } = await fetchCsrData(page, 10);
+  const locale = await getServerLocale();
+  const { content, error } = await fetchCsrData(page, 10, locale);
   // ... metadata logic (same as original)
 }
 
@@ -59,7 +62,8 @@ const PaginationItems = memo(({ currentPage, totalPages }) => {
 export default async function CSR({ searchParams }) {
   const page = (await parseInt(searchParams?.page)) || 1;
   const limit = 10;
-  const { content, csr, sliderData, pagination, error } = await fetchCsrData(page, limit);
+  const locale = await getServerLocale();
+  const { content, csr, sliderData, pagination, error } = await fetchCsrData(page, limit, locale);
   // if (error) {
   //   return (
   //     <div className="container py-10">

--- a/src/app/different-shades-of-indelmoney/page.js
+++ b/src/app/different-shades-of-indelmoney/page.js
@@ -4,10 +4,12 @@ import DifferentShadesIndelSlide from "@/components/features/about/DifferentShad
 
 import MobDifferentShadesIndelSlide from "@/components/features/about/MobDifferentShadesIndelSlide";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchData() {
+async function fetchData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/shades-of-indel`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/shades-of-indel`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -24,9 +26,9 @@ async function fetchData() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=shades`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=shades`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
     });
@@ -104,7 +106,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -116,7 +119,8 @@ export async function generateMetadata() {
 }
 
 export default async function DifferentShadesIndel() {
-  const { contents, values, error } = await fetchData();
+  const locale = await getServerLocale();
+  const { contents, values, error } = await fetchData(locale);
 
   if (!contents || !values) {
     return <div>Failed to fetch Different Shades of Indel data</div>;

--- a/src/app/emptestimonial/page.js
+++ b/src/app/emptestimonial/page.js
@@ -1,11 +1,13 @@
 //export const dynamic = "force-dynamic";
 import Testimonial from "@/pages/Testimonials";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchData(page = 1, limit = 10, type = "all") {
+async function fetchData(page = 1, limit = 10, type = "all", locale) {
   try {
     const response = await fetch(
-      `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/testimonials?page=${page}&limit=${limit}&type=${type}`,
+      buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/testimonials?page=${page}&limit=${limit}&type=${type}`, locale),
       {
         // cache: "no-store", // Ensure fresh data
         cache: "force-cache",
@@ -41,9 +43,9 @@ async function fetchData(page = 1, limit = 10, type = "all") {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=testimonials`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=testimonials`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
     });
@@ -121,7 +123,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -135,8 +138,9 @@ export async function generateMetadata() {
 export default async function EmployeeTestimonial({ searchParams }) {
   const page = (await searchParams?.page) || 1;
   const type = (await searchParams?.type) || "all";
+  const locale = await getServerLocale();
 
-  const { testimonials, pagination, contents, error } = await fetchData(page, 2, type);
+  const { testimonials, pagination, contents, error } = await fetchData(page, 2, type, locale);
 
   if (error) {
     return <div>{error}</div>;

--- a/src/app/gallery/[slug]/page.js
+++ b/src/app/gallery/[slug]/page.js
@@ -2,10 +2,12 @@
 //export const dynamic = "force-dynamic";
 import GalleryDetail from "@/components/features/gallery/GalleryDetail";
 import GallerySlider from "../../../components/features/gallery/GallerySlider";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchMoreGalleryItems(slug) {
+async function fetchMoreGalleryItems(slug, locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/more-events?slug=${slug}`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/more-events?slug=${slug}`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -38,7 +40,8 @@ async function fetchMoreGalleryItems(slug) {
 
 export default async function GalleryDetailPage({ params, searchParams }) {
   const { slug } = await params;
-  const { galleryItems, description, error: moreError } = await fetchMoreGalleryItems(slug);
+  const locale = await getServerLocale();
+  const { galleryItems, description, error: moreError } = await fetchMoreGalleryItems(slug, locale);
 
   return (
     <>

--- a/src/app/gallery/page.js
+++ b/src/app/gallery/page.js
@@ -3,10 +3,12 @@ import Gallery from "@/components/features/gallery/Gallery";
 import MobGallery from "@/components/features/gallery/MobGallery";
 import NoContents from "@/components/NoContents";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchData(page = 1, type = "all", limit = 6) {
+async function fetchData(page = 1, type = "all", limit = 6, locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/event-gallery?page=${page}&limit=${limit}&type=${type}`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/event-gallery?page=${page}&limit=${limit}&type=${type}`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -43,9 +45,9 @@ async function fetchData(page = 1, type = "all", limit = 6) {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=gallery`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=gallery`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
     });
@@ -123,7 +125,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -139,8 +142,9 @@ export default async function GalleryPage({ searchParams }) {
 
   const page = resolvedSearchParams?.page || 1;
   const type = resolvedSearchParams?.type || "all";
+  const locale = await getServerLocale();
 
-  const { contents, medias, sliderItems, pagination, error } = await fetchData(page, type);
+  const { contents, medias, sliderItems, pagination, error } = await fetchData(page, type, undefined, locale);
 
   if (!contents || !medias || !sliderItems) {
     return <NoContents />;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,10 +3,19 @@
 @import url('~leaflet.markercluster/dist/MarkerCluster.Default.css');
 
 
-@theme {
+/* Font tokens must live in `@theme inline`, not `@theme`. They reference the
+   next/font variables, which are declared on <body>. A plain @theme token
+   substitutes its var()s at :root, where those variables don't exist - that
+   makes the whole token invalid, so font-family falls back to preflight's
+   system sans and --font-noto-tamil is never referenced by anything (rendering
+   Tamil as tofu). `inline` inlines the value into the utility instead, so the
+   var()s resolve on <body> where they're defined. */
+@theme inline {
   --font-amino: "Amino", sans-serif;
-  --font-montserrat: "Montserrat", sans-serif;
+  --font-montserrat: var(--font-montserrat-base), var(--font-noto-tamil), sans-serif;
+}
 
+@theme {
   --color-base1: #17479e;
   --color-base2: #ee3824;
   --color-base3: #b7d0ff;

--- a/src/app/gold-loan/page.js
+++ b/src/app/gold-loan/page.js
@@ -3,14 +3,16 @@ import Script from "next/script";
 import { defaultMeta } from "@/constants/constants";
 import GoldLoanClient from "../../pages/GoldLoanClient";
 import { headers } from "next/headers";
+import { getServerLocale } from "../../lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "../../lib/locale/localizedUrl";
 
 function isMobileDevice(userAgent) {
   return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(userAgent);
 }
 
-async function fetchGoldLoanData() {
+async function fetchGoldLoanData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/gold-loan`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/gold-loan`, locale), {
       cache: "no-store",
       credentials: "include", // Ensures session cookie is sent
       headers: {
@@ -59,9 +61,9 @@ async function fetchGoldLoanData() {
   }
 }
 
-async function fetchGoldRate() {
+async function fetchGoldRate(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/gold-rate`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/gold-rate`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
       headers: {
@@ -81,9 +83,9 @@ async function fetchGoldRate() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=goldloan`);
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=goldloan`, locale));
     const result = await response.json();
     const meta = result.data;
 
@@ -158,7 +160,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -170,9 +173,10 @@ export async function generateMetadata() {
 }
 
 export default async function GoldLoan() {
-  const { steps, contents, bannerIcons, schemes, faqs, features, GoldloanBenefits, announcement } = await fetchGoldLoanData();
+  const locale = await getServerLocale();
+  const { steps, contents, bannerIcons, schemes, faqs, features, GoldloanBenefits, announcement } = await fetchGoldLoanData(locale);
   const flattenedFeatures = features?.flat()?.filter((item) => !item.is_center);
-  const { data: goldRateData, error: goldRateError } = await fetchGoldRate();
+  const { data: goldRateData, error: goldRateError } = await fetchGoldRate(locale);
 
   console.log("Faqs:", faqs);
 

--- a/src/app/history-of-indel/page.js
+++ b/src/app/history-of-indel/page.js
@@ -3,10 +3,12 @@ import IndelHistory from "../../components/features/history/IndelHistory";
 import YearsInception from "../../components/features/history/YearsInception";
 import MobYearsInception from "../../components/features/history/MobYearsInception";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "../../lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "../../lib/locale/localizedUrl";
 
-async function fetchHistoryData() {
+async function fetchHistoryData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/history`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/history`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -22,9 +24,9 @@ async function fetchHistoryData() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=history`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=history`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
     });
@@ -102,7 +104,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -114,7 +117,8 @@ export async function generateMetadata() {
 }
 
 export default async function History() {
-  const { contents, images, inceptions, error } = await fetchHistoryData();
+  const locale = await getServerLocale();
+  const { contents, images, inceptions, error } = await fetchHistoryData(locale);
 
   if (!contents || !images || !inceptions) {
     return <div>Failed to fetch history data</div>;

--- a/src/app/indel-money-cares/[slug]/page.js
+++ b/src/app/indel-money-cares/[slug]/page.js
@@ -2,11 +2,13 @@
 import EventDetail from "@/components/features/indel-money-cares/EventDetail";
 import RecentEvents from "@/components/features/indel-money-cares/RecentEvents";
 import { notFound } from "next/navigation";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
 // Fetch blog data for a specific post
-async function fetchEventData(slug) {
+async function fetchEventData(slug, locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/indel-cares/${slug}`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/indel-cares/${slug}`, locale), {
       //   next: { revalidate: 60 },
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -66,9 +68,9 @@ const defaultMetadata = (slug = "indel-money-cares") => ({
   },
 });
 
-async function getMetaData(slug) {
+async function getMetaData(slug, locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta-slug?page=csrItem&slug=${slug}`);
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta-slug?page=csrItem&slug=${slug}`, locale));
     const result = await response.json();
     const meta = result.data;
 
@@ -93,7 +95,8 @@ async function getMetaData(slug) {
 // Generate dynamic metadata
 export async function generateMetadata({ params }) {
   const { slug } = await params;
-  const { meta, error } = await getMetaData(slug);
+  const locale = await getServerLocale();
+  const { meta, error } = await getMetaData(slug, locale);
 
   if (!meta || error) {
     return defaultMetadata(slug);
@@ -130,7 +133,8 @@ export async function generateMetadata({ params }) {
 
 export default async function IndelEvent({ params }) {
   const { slug } = await params;
-  const { data: eventData, recentEvents, title, error: eventError } = await fetchEventData(slug);
+  const locale = await getServerLocale();
+  const { data: eventData, recentEvents, title, error: eventError } = await fetchEventData(slug, locale);
 
   // Handle error state for blog data
   if (eventError || !eventData) {

--- a/src/app/indel-money-cares/page.js
+++ b/src/app/indel-money-cares/page.js
@@ -1,10 +1,12 @@
 //export const dynamic = "force-dynamic";
 import IndelCares from "@/pages/IndelCares";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchData(page = 1, limit = 3) {
+async function fetchData(page = 1, limit = 3, locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/indel-cares?page=${page}&limit=${limit}`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/indel-cares?page=${page}&limit=${limit}`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -46,9 +48,9 @@ async function fetchData(page = 1, limit = 3) {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=indelcares`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=indelcares`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
     });
@@ -126,7 +128,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -139,7 +142,8 @@ export async function generateMetadata() {
 
 export default async function Partners({ searchParams }) {
   const { page } = (await searchParams) || 1;
-  const { content, slideItems, nonSlideItems, totalPages, currentPage, limit, error } = await fetchData(page);
+  const locale = await getServerLocale();
+  const { content, slideItems, nonSlideItems, totalPages, currentPage, limit, error } = await fetchData(page, undefined, locale);
 
   if (!content && !slideItems && !nonSlideItems) {
     return <div>Failed to fetch indel data</div>;

--- a/src/app/indel-values/page.js
+++ b/src/app/indel-values/page.js
@@ -4,10 +4,12 @@ import MobIndelValueBanner from "@/components/features/about/MobIndelValueBanner
 import OurValues from "@/components/features/about/OurValues";
 import OurApproach from "@/components/features/about/OurApproach";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchData() {
+async function fetchData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/indel-values`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/indel-values`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -30,9 +32,9 @@ async function fetchData() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=indelValues`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=indelValues`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
     });
@@ -110,7 +112,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -122,7 +125,8 @@ export async function generateMetadata() {
 }
 
 export default async function IndelValues() {
-  const { contents, values, propositions, mobileBanners, error } = await fetchData();
+  const locale = await getServerLocale();
+  const { contents, values, propositions, mobileBanners, error } = await fetchData(locale);
 
   if (!contents || !values || !propositions) {
     return <div>Failed to fetch Indel Values data</div>;

--- a/src/app/investors-contact/page.js
+++ b/src/app/investors-contact/page.js
@@ -1,10 +1,12 @@
 //export const dynamic = "force-dynamic";
 import React from "react";
 import Contact from "../../components/features/investors/Contact";
+import { getServerLocale } from "../../lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "../../lib/locale/localizedUrl";
 
-async function fetchContactData() {
+async function fetchContactData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/investors/contact`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/investors/contact`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -36,7 +38,8 @@ async function fetchContactData() {
 }
 
 export default async function contact() {
-  const { content, pdf_contacts, text_contacts, error } = await fetchContactData();
+  const locale = await getServerLocale();
+  const { content, pdf_contacts, text_contacts, error } = await fetchContactData(locale);
 
   const contacts = text_contacts;
 

--- a/src/app/investors/csr/page.js
+++ b/src/app/investors/csr/page.js
@@ -2,10 +2,12 @@
 
 import React from "react";
 import CsrDetailsSection from "../../../components/features/investors/CsrDetailsSection";
+import { getServerLocale } from "../../../lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "../../../lib/locale/localizedUrl";
 
-async function fetchCsrData() {
+async function fetchCsrData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/investors/csr-details`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/investors/csr-details`, locale), {
       // cache: 'no-store', // or 'force-cache' depending on your needs
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -36,7 +38,8 @@ async function fetchCsrData() {
 }
 
 export default async function contact() {
-  const { contents, reports, commitee, actionPlans, error } = await fetchCsrData();
+  const locale = await getServerLocale();
+  const { contents, reports, commitee, actionPlans, error } = await fetchCsrData(locale);
 
   if (!contents && !reports && !commitee && !actionPlans) {
     return <div>Failed to fetch report data</div>;

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,8 +1,8 @@
 import "./globals.css";
-import { Montserrat } from "next/font/google";
+import { Montserrat, Noto_Sans_Tamil } from "next/font/google";
 import Header from "../components/layout/header/Header";
 import Footer from "../components/layout/footer/Footer";
-import FloatingButton from "../components/common/FloatingButton";
+// import FloatingButton from "../components/common/FloatingButton";
 import { Toaster } from "react-hot-toast";
 import api from "../lib/api/axios";
 import { GoogleTagManager } from "@next/third-parties/google";
@@ -11,7 +11,18 @@ import { GoogleAnalytics } from "@next/third-parties/google";
 const montserrat = Montserrat({
   subsets: ["latin"],
   weight: ["300", "400", "500", "600", "700", "800", "900"],
-  variable: "--font-montserrat",
+  variable: "--font-montserrat-base",
+  display: "swap",
+});
+
+// Montserrat ships no Tamil subset, so Tamil text needs a dedicated face or it
+// renders as tofu on machines without a Tamil system font. Chained after
+// Montserrat in --font-montserrat (globals.css). Weight is omitted to get the
+// variable font: the site uses 300-900 and static weights would only cover the
+// ones enumerated here.
+const notoSansTamil = Noto_Sans_Tamil({
+  subsets: ["tamil"],
+  variable: "--font-noto-tamil",
   display: "swap",
 });
 
@@ -38,7 +49,7 @@ export default async function RootLayout({ children }) {
   return (
     <html lang="en">
       <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID} />
-      <body className={`${montserrat.variable} font-montserrat min-h-screen flex flex-col antialiased`}>
+      <body className={`${montserrat.variable} ${notoSansTamil.variable} font-montserrat min-h-screen flex flex-col antialiased`}>
         <Header />
         <main className="flex-grow mt-[var(--header-y)]">{children}</main>
         <Footer content={footerContent} icons={footerIcons} />

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -7,6 +7,8 @@ import { Toaster } from "react-hot-toast";
 import api from "../lib/api/axios";
 import { GoogleTagManager } from "@next/third-parties/google";
 import { GoogleAnalytics } from "@next/third-parties/google";
+import { getServerLocale } from "../lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "../lib/locale/localizedUrl";
 
 const montserrat = Montserrat({
   subsets: ["latin"],
@@ -33,11 +35,13 @@ export const metadata = {
 };
 
 export default async function RootLayout({ children }) {
+  const locale = await getServerLocale();
+
   let footerContent = "";
   let footerIcons = [];
 
   try {
-    const res = await api.get("/web/footer", { cache: "no-store", next: { revalidate: 600 } });
+    const res = await api.get(buildLocalizedUrl("/web/footer", locale), { cache: "no-store", next: { revalidate: 600 } });
     if (res.data.status === "success") {
       footerContent = res.data.data.content || "";
       footerIcons = res.data.data.icons || [];
@@ -47,7 +51,7 @@ export default async function RootLayout({ children }) {
   }
 
   return (
-    <html lang="en">
+    <html lang={locale}>
       <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID} />
       <body className={`${montserrat.variable} ${notoSansTamil.variable} font-montserrat min-h-screen flex flex-col antialiased`}>
         <Header />

--- a/src/app/loan-against-property/page.js
+++ b/src/app/loan-against-property/page.js
@@ -2,13 +2,15 @@
 import { headers } from "next/headers";
 import LAPClient from "../../pages/LAPClient";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "../../lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "../../lib/locale/localizedUrl";
 
 function isMobileDevice(userAgent) {
   return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(userAgent);
 }
-async function fetchData() {
+async function fetchData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/loan-against-property`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/loan-against-property`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
     });
@@ -31,9 +33,9 @@ async function fetchData() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=lap`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=lap`, locale), {
       // cache: "force-cache",
       // next: { revalidate: 600 },
     });
@@ -111,7 +113,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -123,7 +126,8 @@ export async function generateMetadata() {
 }
 
 export default async function Services() {
-  const { contents, benfits, products, faqs, error } = await fetchData();
+  const locale = await getServerLocale();
+  const { contents, benfits, products, faqs, error } = await fetchData(locale);
 
   const headersList = await headers(); // ✅ await here
   const userAgent = headersList.get("user-agent") || "";

--- a/src/app/management-team/page.js
+++ b/src/app/management-team/page.js
@@ -1,10 +1,12 @@
 //export const dynamic = "force-dynamic";
 import ManagementTeam from "@/components/features/management-team/ManagementTeam";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchManagementData() {
+async function fetchManagementData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/management`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/management`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -20,9 +22,9 @@ async function fetchManagementData() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=management`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=management`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
     });
@@ -100,7 +102,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -112,7 +115,8 @@ export async function generateMetadata() {
 }
 
 export default async function ManagementTeamPage() {
-  const { data, error } = await fetchManagementData();
+  const locale = await getServerLocale();
+  const { data, error } = await fetchManagementData(locale);
 
   if (!data) {
     return <div>Failed to fetch management data</div>;

--- a/src/app/msme-loan/page.js
+++ b/src/app/msme-loan/page.js
@@ -2,13 +2,15 @@
 import Script from "next/script";
 import MsmeLoanClient from "@/pages/MsmeClient";
 import { headers } from "next/headers";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
 function isMobileDevice(userAgent) {
   return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(userAgent);
 }
-async function fetchData() {
+async function fetchData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/msme`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/msme`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -48,9 +50,9 @@ async function fetchData() {
     };
   }
 }
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=msme`);
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=msme`, locale));
     const result = await response.json();
     const meta = result.data;
 
@@ -79,7 +81,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords } = await getMetaData(locale);
 
   return {
     title,
@@ -89,7 +92,8 @@ export async function generateMetadata() {
 }
 
 export default async function MsmeLoan() {
-  const { contents, offerings, faqs, loanTypes, industries, audience, error } = await fetchData();
+  const locale = await getServerLocale();
+  const { contents, offerings, faqs, loanTypes, industries, audience, error } = await fetchData(locale);
 
   const headersList = await headers();
   const userAgent = headersList.get("user-agent") || "";

--- a/src/app/ncd-issue/page.js
+++ b/src/app/ncd-issue/page.js
@@ -1,10 +1,12 @@
 import NcdInfo from "@/components/features/ncd-issues/NcdInfo";
 import NoContents from "@/components/NoContents";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchNcdData() {
+async function fetchNcdData(locale) {
   try {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/ncd-forms`, {
+    const res = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/ncd-forms`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 }, // revalidate cache every 10 minutes
     });
@@ -23,9 +25,9 @@ async function fetchNcdData() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=ncd`);
+    const res = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=ncd`, locale));
     const result = await res.json();
 
     if (result.status === "success") {
@@ -100,12 +102,14 @@ async function getMetaData() {
 
 // Generate metadata for SEO
 export async function generateMetadata() {
-  const meta = await getMetaData();
+  const locale = await getServerLocale();
+  const meta = await getMetaData(locale);
   return meta;
 }
 
 export default async function NcdPage() {
-  const { data, error } = await fetchNcdData();
+  const locale = await getServerLocale();
+  const { data, error } = await fetchNcdData(locale);
 
   if (!data) {
     return <NoContents />;

--- a/src/app/ncd/page.js
+++ b/src/app/ncd/page.js
@@ -1,10 +1,12 @@
 //export const dynamic = "force-dynamic";
 import React from "react";
 import NcdReports from "@/components/features/investors/NcdReports";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchNcdData() {
+async function fetchNcdData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/investors/ncd-reports`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/investors/ncd-reports`, locale), {
       // cache: 'no-store', // or 'force-cache' depending on your needs
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -33,7 +35,8 @@ async function fetchNcdData() {
 }
 
 export default async function report() {
-  const { contents, currentReports, pastReports, error } = await fetchNcdData();
+  const locale = await getServerLocale();
+  const { contents, currentReports, pastReports, error } = await fetchNcdData(locale);
 
   if (!contents && currentReports.length === 0 && pastReports.length === 0) {
     return <div>Failed to fetch report data</div>;

--- a/src/app/news/[slug]/page.js
+++ b/src/app/news/[slug]/page.js
@@ -2,11 +2,13 @@
 import BlogDetail from "@/components/features/blog/BlogDetail";
 import RecentBlog from "@/components/features/blog/RecentBlog";
 import { notFound } from "next/navigation";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
 // Fetch news data for a specific post
-async function fetchBlogData(slug) {
+async function fetchBlogData(slug, locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/news/${slug}`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/news/${slug}`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
     });
@@ -65,9 +67,9 @@ const defaultMetadata = (slug = "") => ({
   },
 });
 
-async function getMetaData(slug) {
+async function getMetaData(slug, locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta-slug?page=newsItem&slug=${slug}`);
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta-slug?page=newsItem&slug=${slug}`, locale));
     const result = await response.json();
     const meta = result.data;
 
@@ -92,7 +94,8 @@ async function getMetaData(slug) {
 // Generate dynamic metadata
 export async function generateMetadata({ params }) {
   const { slug } = await params;
-  const { meta, error } = await getMetaData(slug);
+  const locale = await getServerLocale();
+  const { meta, error } = await getMetaData(slug, locale);
 
   if (!meta || error) {
     return defaultMetadata(slug);
@@ -129,8 +132,9 @@ export async function generateMetadata({ params }) {
 
 export default async function News({ params }) {
   const { slug } = params;
+  const locale = await getServerLocale();
 
-  const { data: newsData, recentNews, title, error } = await fetchBlogData(slug);
+  const { data: newsData, recentNews, title, error } = await fetchBlogData(slug, locale);
 
   // Handle error state for news data
   if (error || !newsData) {

--- a/src/app/news/page.js
+++ b/src/app/news/page.js
@@ -2,10 +2,12 @@
 import LatestNews from "@/pages/LatestNews";
 import AllNewsPage from "@/pages/AllNews";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=news`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=news`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
     });
@@ -83,7 +85,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,

--- a/src/app/ombudsman/page.js
+++ b/src/app/ombudsman/page.js
@@ -1,10 +1,12 @@
 //export const dynamic = "force-dynamic";
 import Ombudsman from "@/components/features/ombudsman/Ombudsman";
 import NoContents from "@/components/NoContents";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchData() {
+async function fetchData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/ombudsman`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/ombudsman`, locale), {
       // cache: "no-store",
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -32,7 +34,8 @@ async function fetchData() {
 }
 
 export default async function Ombudsmans() {
-  const { data: files, error } = await fetchData(); // ← Fixed destructuring
+  const locale = await getServerLocale();
+  const { data: files, error } = await fetchData(locale); // ← Fixed destructuring
   // Handle not found case
   if (!files || files.length === 0) {
     <NoContents />;

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -3,16 +3,18 @@ import { headers } from "next/headers";
 import Script from "next/script";
 import HomeClient from "../pages/HomeClient";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "../lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "../lib/locale/localizedUrl";
 
 function isMobileDevice(userAgent) {
   return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(userAgent);
 }
 
-async function fetchHomeData() {
+async function fetchHomeData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/home`, {
-      cache: "force-cache",
-      next: { revalidate: 600 },
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/home`, locale), {
+      // cache: "force-cache",
+      // next: { revalidate: 600 },
       credentials: "include", // Ensures session cookie is sent
       headers: {
         "Content-Type": "application/json",
@@ -30,9 +32,9 @@ async function fetchHomeData() {
   }
 }
 
-async function fetchGoldRate() {
+async function fetchGoldRate(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/gold-rate`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/gold-rate`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
       headers: {
@@ -52,11 +54,11 @@ async function fetchGoldRate() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=home`, {
-      cache: "force-cache",
-      next: { revalidate: 600 },
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=home`, locale), {
+      // cache: "force-cache",
+      // next: { revalidate: 600 },
     });
     const result = await response.json();
     const meta = result.data;
@@ -132,7 +134,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -144,8 +147,9 @@ export async function generateMetadata() {
 }
 
 export default async function HomePage() {
-  const { data, error } = await fetchHomeData();
-  const { data: goldRateData, error: goldRateError } = await fetchGoldRate();
+  const locale = await getServerLocale();
+  const { data, error } = await fetchHomeData(locale);
+  const { data: goldRateData, error: goldRateError } = await fetchGoldRate(locale);
 
   const headersList = await headers(); // ✅ await here
   const userAgent = headersList.get("user-agent") || "";

--- a/src/app/partners/page.js
+++ b/src/app/partners/page.js
@@ -1,9 +1,11 @@
 //export const dynamic = "force-dynamic";
 import PartnersSection from "@/components/partners/Partners";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchPartnersData() {
+async function fetchPartnersData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/partners`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/partners`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -19,9 +21,9 @@ async function fetchPartnersData() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=partners`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=partners`, locale), {
       cache: "force-cache",
       next: { revalidate: 600 },
     });
@@ -53,7 +55,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords } = await getMetaData(locale);
 
   return {
     title,
@@ -63,7 +66,8 @@ export async function generateMetadata() {
 }
 
 export default async function Partners() {
-  const { data, partners, error } = await fetchPartnersData();
+  const locale = await getServerLocale();
+  const { data, partners, error } = await fetchPartnersData(locale);
 
   if (!data && !partners) {
     return <div>Failed to fetch partners data</div>;

--- a/src/app/policies/page.js
+++ b/src/app/policies/page.js
@@ -1,11 +1,13 @@
 //export const dynamic = "force-dynamic";
 import React from "react";
 import Policies from "../../components/features/investors/Policies";
+import { getServerLocale } from "../../lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "../../lib/locale/localizedUrl";
 
-async function fetchPolicyData(page = 1, limit = 10) {
+async function fetchPolicyData(page = 1, limit = 10, locale) {
   try {
     const catResponse = await fetch(
-      `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/investors/policy_categories`,
+      buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/investors/policy_categories`, locale),
       {
         // cache: "no-store", // or 'force-cache' depending on your needs
         cache: "force-cache",
@@ -22,7 +24,7 @@ async function fetchPolicyData(page = 1, limit = 10) {
     }
 
     const response = await fetch(
-      url,
+      buildLocalizedUrl(url, locale),
       {
         // cache: "no-store", // or 'force-cache' depending on your needs
         cache: "force-cache",
@@ -69,8 +71,9 @@ async function fetchPolicyData(page = 1, limit = 10) {
 
 export default async function Policy({ searchParams }) {
   const page = (await searchParams?.page) || 1;
+  const locale = await getServerLocale();
 
-  const { content, policies, categories, totalPages, currentPage, limit, error } = await fetchPolicyData(page);
+  const { content, policies, categories, totalPages, currentPage, limit, error } = await fetchPolicyData(page, undefined, locale);
 
   if (!content && !policies && !totalPages && !currentPage && !limit) {
     return <div>Failed to fetch policy data</div>;

--- a/src/app/services/page.js
+++ b/src/app/services/page.js
@@ -4,10 +4,12 @@ import OtherGoldLoan from "@/components/features/services/OtherGoldLoan";
 import SmartMoneyDeal from "@/components/features/services/SmartMoneyDeal";
 import IndelRemit from "@/components/features/services/IndelRemit";
 import { defaultMeta } from "@/constants/constants";
+import { getServerLocale } from "@/lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "@/lib/locale/localizedUrl";
 
-async function fetchManagementData() {
+async function fetchManagementData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/our-services`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/our-services`, locale), {
       // cache: "no-store", // Ensure fresh data
       cache: "force-cache",
       next: { revalidate: 600 },
@@ -30,9 +32,9 @@ async function fetchManagementData() {
   }
 }
 
-async function getMetaData() {
+async function getMetaData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=services`);
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/meta?page=services`, locale));
     const result = await response.json();
     const meta = result.data;
 
@@ -107,7 +109,8 @@ async function getMetaData() {
 }
 
 export async function generateMetadata() {
-  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData();
+  const locale = await getServerLocale();
+  const { title, description, keywords, twitter, openGraph, alternates } = await getMetaData(locale);
   return {
     title,
     description,
@@ -119,7 +122,8 @@ export async function generateMetadata() {
 }
 
 export default async function Services() {
-  const { serviceContent, services, serviceBenefit, error } = await fetchManagementData();
+  const locale = await getServerLocale();
+  const { serviceContent, services, serviceBenefit, error } = await fetchManagementData(locale);
 
   if ((!serviceContent && !services && !serviceBenefit) || error) {
     return <div>Failed to fetch service data</div>;

--- a/src/components/layout/header/DeskHeader.js
+++ b/src/components/layout/header/DeskHeader.js
@@ -27,7 +27,7 @@ function ContactBox({ href, src, title, alt }) {
   );
 }
 
-export default function DeskHeader({ headerData }) {
+export default function DeskHeader({ headerData, locale }) {
   const header = headerData?.content;
   const common = headerData?.footerContent;
   const modes = headerData?.modes;
@@ -90,7 +90,7 @@ export default function DeskHeader({ headerData }) {
                   />
                 </div>
                 <div className="hidden lg:block">
-                  <TranslatorDropdown />
+                  <TranslatorDropdown ssrLocale={locale} />
                 </div>
                 {/* <div>
                   <ContactBox

--- a/src/components/layout/header/DeskHeader.js
+++ b/src/components/layout/header/DeskHeader.js
@@ -14,6 +14,7 @@ import {
 } from "../../ui/dropdown-menu";
 import { useEffect, useState } from "react";
 import NavMenu from "./NavMenu";
+import TranslatorDropdown from "./TranslatorDropdown";
 
 function ContactBox({ href, src, title, alt }) {
   return (
@@ -87,6 +88,9 @@ export default function DeskHeader({ headerData }) {
                     title={common?.branch_locator ? common?.branch_locator : "Branch Locator"}
                     alt="location"
                   />
+                </div>
+                <div className="hidden lg:block">
+                  <TranslatorDropdown />
                 </div>
                 {/* <div>
                   <ContactBox

--- a/src/components/layout/header/Header.js
+++ b/src/components/layout/header/Header.js
@@ -1,10 +1,12 @@
 import MobHeader from "./MobHeader";
 import DeskHeader from "./DeskHeader";
 import "./Header.css";
+import { getServerLocale } from "../../../lib/locale/getServerLocale";
+import { buildLocalizedUrl } from "../../../lib/locale/localizedUrl";
 
-async function fetchData() {
+async function fetchData(locale) {
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/header`, {
+    const response = await fetch(buildLocalizedUrl(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/header`, locale), {
       cache: "no-store", // Ensure fresh data
     });
     const result = await response.json();
@@ -24,7 +26,8 @@ async function fetchData() {
 }
 
 export default async function Header() {
-  const { contents: headerData, socialLinks, links, error } = await fetchData();
+  const locale = await getServerLocale();
+  const { contents: headerData, socialLinks, links, error } = await fetchData(locale);
 
   if (error) {
     return <div>{error}</div>;
@@ -33,7 +36,7 @@ export default async function Header() {
   return (
     <>
       <div className="hidden lg:block">
-        <DeskHeader headerData={headerData} />
+        <DeskHeader headerData={headerData} locale={locale} />
       </div>
       <div className="block lg:hidden">
         <MobHeader
@@ -42,6 +45,7 @@ export default async function Header() {
           links={links}
           title={headerData?.content?.button_1_text}
           modes={headerData?.modes}
+          locale={locale}
         />
       </div>
     </>

--- a/src/components/layout/header/MobHeader.js
+++ b/src/components/layout/header/MobHeader.js
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import MobNavMenu from "./MobNavMenu";
+import TranslatorDropdown from "./TranslatorDropdown";
 import { serverMediaPath } from "@/constants/constants";
 
 const socialmedias = [
@@ -161,6 +162,9 @@ export default function MobHeader({ socialLinks, links, logo, title, modes }) {
                   >
                     Apply for NCD
                   </a> */}
+                  <div className="block">
+                    <TranslatorDropdown />
+                  </div>
                   <div>
                     <MobNavMenu logo={logo} serverMediaPath={serverMediaPath} title={title} modes={modes} />
                   </div>

--- a/src/components/layout/header/MobHeader.js
+++ b/src/components/layout/header/MobHeader.js
@@ -58,7 +58,7 @@ const quickactions = [
   },
 ];
 
-export default function MobHeader({ socialLinks, links, logo, title, modes }) {
+export default function MobHeader({ socialLinks, links, logo, title, modes, locale }) {
   const [isVisible, setIsVisible] = useState(true);
   const [prevScrollPos, setPrevScrollPos] = useState(0);
 
@@ -163,7 +163,7 @@ export default function MobHeader({ socialLinks, links, logo, title, modes }) {
                     Apply for NCD
                   </a> */}
                   <div className="block">
-                    <TranslatorDropdown />
+                    <TranslatorDropdown ssrLocale={locale} />
                   </div>
                   <div>
                     <MobNavMenu logo={logo} serverMediaPath={serverMediaPath} title={title} modes={modes} />

--- a/src/components/layout/header/TranslatorDropdown.js
+++ b/src/components/layout/header/TranslatorDropdown.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useId, useRef, useState, useSyncExternalStore } from "react";
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 // All 22 languages in the Constitution's Eighth Schedule except Bodo and
 // Kashmiri, which the backend's translation provider (Google's
@@ -32,8 +32,24 @@ const TRANSLATION_LANGUAGES = [
   { code: "ur", label: "اردو" },
 ];
 
+// Defense in depth against this list and the server's stateLanguageMap.js
+// drifting out of sync — a locale the client doesn't recognize is treated as
+// "nothing returned" rather than applied blindly.
+function isSupportedLanguageCode(code) {
+  return TRANSLATION_LANGUAGES.some((language) => language.code === code);
+}
 
 const BG_TRANSLATE_ENDPOINT = `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/translate`;
+
+// One-shot, best-effort IP-geolocation lookup used only to pick a *default*
+// language for visitors who haven't chosen (or previously been assigned) one
+// yet. Separate concern from BG_TRANSLATE_ENDPOINT, which does per-string translation.
+const LOCALE_DETECT_ENDPOINT = `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/locale-detect`;
+
+// Generous enough a healthy round trip never comes close; short enough a
+// slow/hanging geolocation call can't leave a visitor noticeably longer in
+// English than today's plain default — past this we just abort.
+const LOCALE_DETECT_TIMEOUT_MS = 2500;
 
 // Text nodes directly inside these are never prose: a <textarea>'s text child is
 // the user's own typed value, and the rest are code/markup containers.
@@ -54,6 +70,12 @@ const SKIP_PARENT_TAGS = new Set([
 // TreeWalker only reports text nodes, so without a parallel pass over these the
 // strings are unreachable and always render in English.
 const TRANSLATABLE_ATTRS = ["placeholder", "title", "aria-label", "alt"];
+
+// What the MutationObserver's attributeFilter listens for - a superset of
+// TRANSLATABLE_ATTRS (which collectAttrTargets walks unconditionally on every
+// element) that also includes "content", meaningful only on meta/title
+// elements and gated by METADATA_SELECTOR wherever it's actually handled.
+const OBSERVED_ATTRS = [...TRANSLATABLE_ATTRS, "content"];
 
 // Standard HTML opt-out, honoured on any ancestor.
 const NO_TRANSLATE_SELECTOR = '[translate="no"], .notranslate';
@@ -79,6 +101,7 @@ const translationCache = new Map();
 // other is mid-fetch re-translating it - a race on the shared document.body.
 let sharedLanguage = "en";
 let hasHydratedLanguage = false;
+let hasStartedLocaleDetection = false;
 const languageListeners = new Set();
 
 function getSharedLanguageSnapshot() {
@@ -103,21 +126,91 @@ function setSharedLanguage(next) {
   sharedLanguage = next;
   if (typeof window !== "undefined") {
     window.localStorage.setItem("siteLanguage", next);
+    // Mirrored into a cookie (same name) so getServerLocale.js
+    // (client/src/lib/locale/getServerLocale.js) can pick the same locale for
+    // server-rendered CMS content - localStorage alone is invisible to the
+    // server on the next request/refresh.
+    document.cookie = `siteLanguage=${next}; path=/; max-age=31536000; SameSite=Lax`;
   }
   languageListeners.forEach((listener) => listener());
 }
 
+// Fire-and-forget geolocation default, only ever called from
+// hydrateSharedLanguageOnce below for a genuinely fresh visitor (nothing in
+// storage yet). Local guard kept in addition to that caller's own guard so
+// this stays provably single-shot even if something else calls it later.
+function detectAndApplyGeoLanguage() {
+  if (hasStartedLocaleDetection) return;
+  hasStartedLocaleDetection = true;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), LOCALE_DETECT_TIMEOUT_MS);
+
+  fetch(LOCALE_DETECT_ENDPOINT, { signal: controller.signal, cache: "no-store" })
+    .then((response) => (response.ok ? response.json() : null))
+    .then((result) => {
+      const locale = result?.data?.locale;
+      if (typeof locale !== "string" || !isSupportedLanguageCode(locale)) return;
+
+      // Re-check storage now, not at fetch-start time: the visitor may have
+      // picked a language by hand while this request was in flight, and an
+      // explicit pick always outranks a guessed default.
+      if (window.localStorage.getItem("siteLanguage")) return;
+
+      // Persist directly (not solely via setSharedLanguage): when the
+      // detected locale is "en" (most visitors, since most states/IPs aren't
+      // mapped), setSharedLanguage's own no-op-on-same-value guard would skip
+      // its localStorage write, leaving storage empty forever and re-running
+      // this fetch on every future fresh page load instead of once ever.
+      window.localStorage.setItem("siteLanguage", locale);
+      if (locale !== sharedLanguage) setSharedLanguage(locale);
+    })
+    .catch(() => {
+      // Timeout/abort, network failure, non-OK status, bad JSON - every
+      // failure mode lands here and is swallowed on purpose: nothing a
+      // visitor can act on, and the result matches today's plain "en" default.
+    })
+    .finally(() => {
+      clearTimeout(timeoutId);
+    });
+}
+
 // Runs from every mounted instance's mount effect, but the module-level
 // guard means only the first one to fire actually reads storage - order
-// independent, which is what removes the old two-instance mount race.
-function hydrateSharedLanguageOnce() {
+// independent, which is what removes the old two-instance mount race. The
+// guard is set synchronously as the first statement, before
+// detectAndApplyGeoLanguage (which only *starts* a fetch, never awaits it) -
+// so the second instance's call in the same synchronous tick always sees
+// hasHydratedLanguage already flipped and returns at the top.
+function hydrateSharedLanguageOnce(ssrLocale) {
   if (hasHydratedLanguage) return;
   hasHydratedLanguage = true;
   if (typeof window === "undefined") return;
+
   const stored = window.localStorage.getItem("siteLanguage");
-  if (stored && stored !== sharedLanguage) {
-    setSharedLanguage(stored);
+  if (stored) {
+    if (stored !== sharedLanguage) setSharedLanguage(stored);
+    return; // Already resolved (explicit pick or a previous visit's
+    // geolocation default) - sticky either way, geolocation is never
+    // re-consulted once anything is stored.
   }
+
+  // The server already resolved a real (non-English) locale for this request
+  // via the same IP-geolocation lookup detectAndApplyGeoLanguage would run -
+  // trust it directly instead of re-fetching, which is what caused the old
+  // English-then-translated flash. An "en" ssrLocale is ambiguous (could be a
+  // genuinely English-mapped visitor, or a failed/timed-out server lookup),
+  // so that case still falls through to the client-side detection below.
+  if (ssrLocale && ssrLocale !== "en" && isSupportedLanguageCode(ssrLocale)) {
+    window.localStorage.setItem("siteLanguage", ssrLocale);
+    if (ssrLocale !== sharedLanguage) setSharedLanguage(ssrLocale);
+    return;
+  }
+
+  // Genuinely fresh visitor (or ambiguous "en") - kick off geolocation-based
+  // detection in the background. Never blocks this synchronous mount effect
+  // (or SSR, which never runs this path) from returning immediately.
+  detectAndApplyGeoLanguage();
 }
 
 // Distinguishes prose from identifiers. Attribute values especially are often
@@ -187,6 +280,13 @@ function collectAttrTargets(element, targets) {
   TRANSLATABLE_ATTRS.forEach((attr) => {
     if (isEligibleAttr(element, attr)) targets.push(attrTarget(element, attr));
   });
+  // Newly-added <head> nodes (title/meta swapped in via childList) carry their
+  // text in "content", not one of TRANSLATABLE_ATTRS - scoped to
+  // METADATA_SELECTOR so this doesn't turn into a blanket check of every
+  // element's "content" attribute.
+  if (element.matches?.(METADATA_SELECTOR) && isEligibleAttr(element, "content")) {
+    targets.push(attrTarget(element, "content"));
+  }
 }
 
 function collectTargets(root) {
@@ -284,7 +384,7 @@ async function translateTexts(targetLocale, texts) {
   return texts.map((text) => translationCache.get(`${targetLocale}::${text}`) ?? text);
 }
 
-export default function TranslatorDropdown() {
+export default function TranslatorDropdown({ ssrLocale = "en" }) {
   const selectedLanguage = useSyncExternalStore(
     subscribeToSharedLanguage,
     getSharedLanguageSnapshot,
@@ -297,6 +397,7 @@ export default function TranslatorDropdown() {
   const flushTimeoutRef = useRef(null);
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const router = useRouter();
   const routeKey = `${pathname}?${searchParams.toString()}`;
   const langSelectId = useId();
 
@@ -305,8 +406,8 @@ export default function TranslatorDropdown() {
   }, [selectedLanguage]);
 
   useEffect(() => {
-    hydrateSharedLanguageOnce();
-  }, []);
+    hydrateSharedLanguageOnce(ssrLocale);
+  }, [ssrLocale]);
 
   const translateTargets = useCallback((targets) => {
     const store = originalValueMap.current;
@@ -341,6 +442,10 @@ export default function TranslatorDropdown() {
       items.map((item) => item.trimmed),
     )
       .then((translatedTexts) => {
+        // A newer language selection may have superseded this in-flight
+        // request - dropping a stale response here (rather than writing it)
+        // stops it from clobbering whatever the latest selection produces.
+        if (languageRef.current !== locale) return;
         translatedTexts.forEach((translated, index) => {
           const { target, original, leading, trailing } = items[index];
           const written = `${leading}${translated}${trailing}`;
@@ -360,16 +465,27 @@ export default function TranslatorDropdown() {
   // route (path or query string) changes so newly-navigated pages - including
   // query-string-only pagination like blog/news "next page" - get translated
   // instead of staying in English until the language is re-selected.
-  // <head> rides along here rather than in the observer below: it isn't under
-  // document.body, and a route change is exactly when Next.js swaps it.
+  // <head> rides along here too, as the fast (non-debounced) path for the
+  // common case; the observer below now also covers document.documentElement
+  // (head included) as a catch-all for head mutations that land after this
+  // pass already ran - e.g. Next streaming in a new <title> a tick late.
   useEffect(() => {
     if (typeof window === "undefined") return;
     // Keep the declared language matching the script actually rendered - both
     // for screen readers and because browsers consult it when picking a
     // fallback face for generic families.
     document.documentElement.lang = selectedLanguage;
+
+    // Some CMS-driven content (server/middlewares/translateMiddleware.js, via
+    // buildLocalizedUrl in the page's data fetches) may already be rendered
+    // in this locale when selectedLanguage === ssrLocale, but plenty of body
+    // text - hardcoded nav/footer labels, anything outside the CMS fetches -
+    // never goes through that pipeline and still needs this pass every time.
+    // Re-running here on already-translated text is safe: isTranslatableValue
+    // requires an ASCII letter, and none of TRANSLATION_LANGUAGES use a Latin
+    // script, so real translated strings just fail that check and pass through.
     translateTargets([...collectTargets(document.body), ...collectMetadataTargets()]);
-  }, [selectedLanguage, routeKey, translateTargets]);
+  }, [selectedLanguage, routeKey, translateTargets, ssrLocale]);
 
   // Catch text that mounts after a pass has already run - dropdown/mega
   // menus, modals, and other content Radix/portals only render once opened.
@@ -413,12 +529,28 @@ export default function TranslatorDropdown() {
         if (mutation.type === "attributes") {
           const element = mutation.target;
           const attr = mutation.attributeName;
+          // "content" is only meaningful on meta/title elements (see
+          // collectAttrTargets) - attributeFilter is document-wide and can't
+          // scope itself, so do it here instead.
+          if (attr === "content" && !element.matches?.(METADATA_SELECTOR)) return;
           const memo = readMemo(originalValueMap.current, element, attr);
           // setAttribute emits a record even when the value is unchanged, so
           // our own writes would re-queue themselves forever. Anything already
           // showing what we last wrote is our echo — drop it.
           if (memo && memo.lastWritten === element.getAttribute(attr)) return;
           if (isEligibleAttr(element, attr)) queue(attrTarget(element, attr));
+          return;
+        }
+
+        if (mutation.type === "characterData") {
+          const node = mutation.target;
+          // CharacterData covers Comment/CDATASection too, not just Text -
+          // Next's streaming/hydration markers are structural comments, some
+          // with ASCII letters, and must never be rewritten.
+          if (node.nodeType !== Node.TEXT_NODE) return;
+          const memo = readMemo(originalValueMap.current, node, TEXT_SLOT);
+          if (memo && memo.lastWritten === node.nodeValue) return;
+          if (isEligibleTextNode(node)) queue(textTarget(node));
           return;
         }
 
@@ -435,11 +567,12 @@ export default function TranslatorDropdown() {
       }, 150);
     });
 
-    observer.observe(document.body, {
+    observer.observe(document.documentElement, {
       childList: true,
       subtree: true,
       attributes: true,
-      attributeFilter: TRANSLATABLE_ATTRS,
+      attributeFilter: OBSERVED_ATTRS,
+      characterData: true,
     });
 
     return () => {
@@ -457,7 +590,15 @@ export default function TranslatorDropdown() {
       <select
         id={langSelectId}
         value={selectedLanguage}
-        onChange={(event) => setSharedLanguage(event.target.value)}
+        onChange={(event) => {
+          setSharedLanguage(event.target.value);
+          // Explicit pick only - not the hydration/geo-detect paths inside
+          // setSharedLanguage, which already match what SSR just rendered and
+          // would otherwise trigger a needless refetch flash on every load.
+          // The cookie write above is synchronous, so this refresh's RSC
+          // fetch already carries the new locale.
+          router.refresh();
+        }}
         disabled={isTranslating}
         // Each option is already written in the language it names, so this
         // subtree must never be rewritten by our own pass.

--- a/src/components/layout/header/TranslatorDropdown.js
+++ b/src/components/layout/header/TranslatorDropdown.js
@@ -1,0 +1,475 @@
+"use client";
+
+import { useCallback, useEffect, useId, useRef, useState, useSyncExternalStore } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+// All 22 languages in the Constitution's Eighth Schedule except Bodo and
+// Kashmiri, which the backend's translation provider (Google's
+// translate-pa.googleapis.com widget endpoint) does not support under any
+// locale code — every code tried for them either errors or is silently
+// echoed back untranslated.
+const TRANSLATION_LANGUAGES = [
+  { code: "en", label: "English" },
+  { code: "as", label: "অসমীয়া" },
+  { code: "bn", label: "বাংলা" },
+  { code: "doi", label: "डोगरी" },
+  { code: "gu", label: "ગુજરાતી" },
+  { code: "hi", label: "हिन्दी" },
+  { code: "kn", label: "ಕನ್ನಡ" },
+  { code: "kok", label: "कोंकणी" },
+  { code: "mai", label: "मैथिली" },
+  { code: "ml", label: "മലയാളം" },
+  { code: "mni-Mtei", label: "ꯃꯤꯇꯩꯂꯣꯟ" },
+  { code: "mr", label: "मराठी" },
+  { code: "ne", label: "नेपाली" },
+  { code: "or", label: "ଓଡ଼ିଆ" },
+  { code: "pa", label: "ਪੰਜਾਬੀ" },
+  { code: "sa", label: "संस्कृतम्" },
+  { code: "sat", label: "ᱥᱟᱱᱛᱟᱲᱤ" },
+  { code: "sd", label: "سنڌي" },
+  { code: "ta", label: "தமிழ்" },
+  { code: "te", label: "తెలుగు" },
+  { code: "ur", label: "اردو" },
+];
+
+
+const BG_TRANSLATE_ENDPOINT = `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/translate`;
+
+// Text nodes directly inside these are never prose: a <textarea>'s text child is
+// the user's own typed value, and the rest are code/markup containers.
+// <select>/<option> are deliberately NOT here — option labels are real UI text.
+// The language switcher opts itself out with translate="no" instead, so its
+// native labels (हिन्दी, தமிழ்) survive.
+const SKIP_PARENT_TAGS = new Set([
+  "script",
+  "style",
+  "noscript",
+  "iframe",
+  "svg",
+  "path",
+  "link",
+]);
+
+// User-visible text that lives in an attribute instead of a text node. The
+// TreeWalker only reports text nodes, so without a parallel pass over these the
+// strings are unreachable and always render in English.
+const TRANSLATABLE_ATTRS = ["placeholder", "title", "aria-label", "alt"];
+
+// Standard HTML opt-out, honoured on any ancestor.
+const NO_TRANSLATE_SELECTOR = '[translate="no"], .notranslate';
+
+// <head> metadata. Only the <title> is user-visible (browser tab); the meta tags
+// are translated for completeness but carry no SEO weight, since crawlers read
+// the server-rendered HTML and never run this pass.
+const METADATA_SELECTOR = 'meta[name="description"], meta[property="og:title"], meta[property="og:description"]';
+
+const TEXT_SLOT = "#text";
+
+// Cached across the whole session so re-translating a page (route change,
+// reopening a dropdown, etc.) doesn't re-hit the translate API for text
+// we've already translated once.
+const translationCache = new Map();
+
+// DeskHeader and MobHeader each mount their own <TranslatorDropdown/> (only
+// one is ever visible per viewport via CSS, but both are always live). A
+// module-level store, rather than per-instance useState, is what keeps them
+// from independently drifting: without it, each instance owns its own copy
+// of "the" selected language, and whichever one still thinks it's "en"
+// synchronously reverts translated text on the next route change while the
+// other is mid-fetch re-translating it - a race on the shared document.body.
+let sharedLanguage = "en";
+let hasHydratedLanguage = false;
+const languageListeners = new Set();
+
+function getSharedLanguageSnapshot() {
+  return sharedLanguage;
+}
+
+// Must never read the mutable sharedLanguage var - this component renders on
+// the server too, and that module state is process-lifetime, not
+// per-request, so leaking it into SSR output would bleed one user's
+// selection into another concurrent request's initial HTML.
+function getServerLanguageSnapshot() {
+  return "en";
+}
+
+function subscribeToSharedLanguage(listener) {
+  languageListeners.add(listener);
+  return () => languageListeners.delete(listener);
+}
+
+function setSharedLanguage(next) {
+  if (next === sharedLanguage) return;
+  sharedLanguage = next;
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem("siteLanguage", next);
+  }
+  languageListeners.forEach((listener) => listener());
+}
+
+// Runs from every mounted instance's mount effect, but the module-level
+// guard means only the first one to fire actually reads storage - order
+// independent, which is what removes the old two-instance mount race.
+function hydrateSharedLanguageOnce() {
+  if (hasHydratedLanguage) return;
+  hasHydratedLanguage = true;
+  if (typeof window === "undefined") return;
+  const stored = window.localStorage.getItem("siteLanguage");
+  if (stored && stored !== sharedLanguage) {
+    setSharedLanguage(stored);
+  }
+}
+
+// Distinguishes prose from identifiers. Attribute values especially are often
+// not text at all — icon paths leak into title=, alt= is frequently a filename,
+// and contact details are digits — so sending them wastes payload and risks
+// rendering a mangled path to the user. Applied to the *source* string, never to
+// a live DOM value: once translated, a node holds no ASCII letters, and testing
+// that would strand it in Tamil forever.
+function isTranslatableValue(value) {
+  if (!value) return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (!/[a-zA-Z]/.test(trimmed)) return false;
+  if (/^(https?:|\/|\.{1,2}\/|data:|mailto:|tel:|#)/i.test(trimmed)) return false;
+  if (/^\S+@\S+\.\S+$/.test(trimmed)) return false;
+  return true;
+}
+
+// A translation target is one writable slot: either a text node's value or a
+// single attribute on an element. Both share this shape so one pass, one cache,
+// and one restore-to-English path cover text, attributes, and metadata alike.
+function textTarget(node) {
+  return {
+    owner: node,
+    slot: TEXT_SLOT,
+    read: () => node.nodeValue,
+    write: (value) => {
+      node.nodeValue = value;
+    },
+  };
+}
+
+function attrTarget(element, attr) {
+  return {
+    owner: element,
+    slot: attr,
+    read: () => element.getAttribute(attr),
+    write: (value) => element.setAttribute(attr, value),
+  };
+}
+
+function isSkippedElement(element) {
+  if (!element) return true;
+  if (element.isContentEditable) return true;
+  return typeof element.closest === "function" && !!element.closest(NO_TRANSLATE_SELECTOR);
+}
+
+function isEligibleTextNode(node) {
+  const value = node.nodeValue;
+  if (!value || !value.trim()) return false;
+  const parent = node.parentNode;
+  if (!parent) return false;
+  if (SKIP_PARENT_TAGS.has(parent.nodeName?.toLowerCase())) return false;
+  return !isSkippedElement(parent);
+}
+
+function isEligibleAttr(element, attr) {
+  if (typeof element.hasAttribute !== "function" || !element.hasAttribute(attr)) return false;
+  const value = element.getAttribute(attr);
+  if (!value || !value.trim()) return false;
+  // next/image consumes placeholder="blur" as a directive, not as user text.
+  if (attr === "placeholder" && element.nodeName.toLowerCase() === "img") return false;
+  return !isSkippedElement(element);
+}
+
+function collectAttrTargets(element, targets) {
+  TRANSLATABLE_ATTRS.forEach((attr) => {
+    if (isEligibleAttr(element, attr)) targets.push(attrTarget(element, attr));
+  });
+}
+
+function collectTargets(root) {
+  const targets = [];
+
+  if (root.nodeType === Node.TEXT_NODE) {
+    if (isEligibleTextNode(root)) targets.push(textTarget(root));
+    return targets;
+  }
+  if (root.nodeType !== Node.ELEMENT_NODE) return targets;
+
+  // A TreeWalker never reports its own root, so cover it before descending.
+  collectAttrTargets(root, targets);
+
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT, null, false);
+  while (walker.nextNode()) {
+    const node = walker.currentNode;
+    if (node.nodeType === Node.TEXT_NODE) {
+      if (isEligibleTextNode(node)) targets.push(textTarget(node));
+    } else {
+      collectAttrTargets(node, targets);
+    }
+  }
+  return targets;
+}
+
+function collectMetadataTargets() {
+  const targets = [];
+  const titleNode = document.querySelector("head > title")?.firstChild;
+  if (titleNode?.nodeValue?.trim()) targets.push(textTarget(titleNode));
+  document.head.querySelectorAll(METADATA_SELECTOR).forEach((element) => {
+    if (element.getAttribute("content")?.trim()) targets.push(attrTarget(element, "content"));
+  });
+  return targets;
+}
+
+function readMemo(store, owner, slot) {
+  return store.get(owner)?.get(slot);
+}
+
+function writeMemo(store, owner, slot, entry) {
+  let slots = store.get(owner);
+  if (!slots) {
+    slots = new Map();
+    store.set(owner, slots);
+  }
+  slots.set(slot, entry);
+}
+
+function normalizeTextNodeValue(text) {
+  const matchLeading = text.match(/^(\s*)/);
+  const matchTrailing = text.match(/(\s*)$/);
+  return {
+    original: text,
+    leading: matchLeading ? matchLeading[1] : "",
+    trailing: matchTrailing ? matchTrailing[1] : "",
+    trimmed: text.trim(),
+  };
+}
+
+async function translateTexts(targetLocale, texts) {
+  const uniqueTexts = [...new Set(texts)];
+  const toFetch = uniqueTexts.filter((text) => !translationCache.has(`${targetLocale}::${text}`));
+
+  if (toFetch.length > 0) {
+    const response = await fetch(BG_TRANSLATE_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ targetLocale, texts: toFetch }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Translation request failed with ${response.status}`);
+    }
+
+    const result = await response.json();
+    if (!result?.data || !Array.isArray(result.data)) {
+      throw new Error("Invalid translation response");
+    }
+
+    toFetch.forEach((text, index) => {
+      const translated = result.data[index];
+      // Never cache a miss. Map.has() reports true for a key set to undefined,
+      // so a short or ragged response would filter this string out of every
+      // later request and strand it in English for the rest of the session.
+      // Leaving it uncached means it simply gets retried on the next pass.
+      if (typeof translated === "string" && translated.trim()) {
+        translationCache.set(`${targetLocale}::${text}`, translated);
+      }
+    });
+  }
+
+  return texts.map((text) => translationCache.get(`${targetLocale}::${text}`) ?? text);
+}
+
+export default function TranslatorDropdown() {
+  const selectedLanguage = useSyncExternalStore(
+    subscribeToSharedLanguage,
+    getSharedLanguageSnapshot,
+    getServerLanguageSnapshot,
+  );
+  const [isTranslating, setIsTranslating] = useState(false);
+  const originalValueMap = useRef(new WeakMap());
+  const languageRef = useRef(selectedLanguage);
+  const pendingRef = useRef(new Map());
+  const flushTimeoutRef = useRef(null);
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const routeKey = `${pathname}?${searchParams.toString()}`;
+  const langSelectId = useId();
+
+  useEffect(() => {
+    languageRef.current = selectedLanguage;
+  }, [selectedLanguage]);
+
+  useEffect(() => {
+    hydrateSharedLanguageOnce();
+  }, []);
+
+  const translateTargets = useCallback((targets) => {
+    const store = originalValueMap.current;
+    const items = targets
+      .map((target) => {
+        const memo = readMemo(store, target.owner, target.slot);
+        const live = target.read();
+        // If the live value no longer matches what we last wrote, something
+        // outside our control changed it (e.g. React reused this DOM node for a
+        // different DB record during a re-render). In that case the cached
+        // "original" is stale — treat the live value as the fresh source text
+        // instead of re-translating old data.
+        const sourceText = memo && memo.lastWritten === live ? memo.original : live;
+        return { target, ...normalizeTextNodeValue(sourceText ?? "") };
+      })
+      .filter((item) => isTranslatableValue(item.trimmed));
+
+    if (items.length === 0) return;
+
+    const locale = languageRef.current;
+    if (locale === "en") {
+      items.forEach(({ target, original }) => {
+        target.write(original);
+        writeMemo(store, target.owner, target.slot, { original, lastWritten: original });
+      });
+      return;
+    }
+
+    setIsTranslating(true);
+    translateTexts(
+      locale,
+      items.map((item) => item.trimmed),
+    )
+      .then((translatedTexts) => {
+        translatedTexts.forEach((translated, index) => {
+          const { target, original, leading, trailing } = items[index];
+          const written = `${leading}${translated}${trailing}`;
+          target.write(written);
+          writeMemo(store, target.owner, target.slot, { original, lastWritten: written });
+        });
+      })
+      .catch((error) => {
+        console.error("Page translation failed:", error);
+      })
+      .finally(() => {
+        setIsTranslating(false);
+      });
+  }, []);
+
+  // Re-run a full pass whenever the language changes, and also whenever the
+  // route (path or query string) changes so newly-navigated pages - including
+  // query-string-only pagination like blog/news "next page" - get translated
+  // instead of staying in English until the language is re-selected.
+  // <head> rides along here rather than in the observer below: it isn't under
+  // document.body, and a route change is exactly when Next.js swaps it.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    // Keep the declared language matching the script actually rendered - both
+    // for screen readers and because browsers consult it when picking a
+    // fallback face for generic families.
+    document.documentElement.lang = selectedLanguage;
+    translateTargets([...collectTargets(document.body), ...collectMetadataTargets()]);
+  }, [selectedLanguage, routeKey, translateTargets]);
+
+  // Catch text that mounts after a pass has already run - dropdown/mega
+  // menus, modals, and other content Radix/portals only render once opened.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const pending = pendingRef.current;
+
+    const queue = (target) => {
+      let slots = pending.get(target.owner);
+      if (!slots) {
+        slots = new Set();
+        pending.set(target.owner, slots);
+      }
+      slots.add(target.slot);
+    };
+
+    // Rebuild targets at flush time rather than holding them from queue time:
+    // it dedupes repeat mutations to the same slot, and drops nodes that were
+    // unmounted again during the debounce window.
+    const drain = () => {
+      const targets = [];
+      pending.forEach((slots, owner) => {
+        if (!owner.isConnected) return;
+        slots.forEach((slot) => {
+          if (slot === TEXT_SLOT) {
+            if (isEligibleTextNode(owner)) targets.push(textTarget(owner));
+          } else if (isEligibleAttr(owner, slot)) {
+            targets.push(attrTarget(owner, slot));
+          }
+        });
+      });
+      pending.clear();
+      return targets;
+    };
+
+    const observer = new MutationObserver((mutations) => {
+      if (languageRef.current === "en") return;
+
+      mutations.forEach((mutation) => {
+        if (mutation.type === "attributes") {
+          const element = mutation.target;
+          const attr = mutation.attributeName;
+          const memo = readMemo(originalValueMap.current, element, attr);
+          // setAttribute emits a record even when the value is unchanged, so
+          // our own writes would re-queue themselves forever. Anything already
+          // showing what we last wrote is our echo — drop it.
+          if (memo && memo.lastWritten === element.getAttribute(attr)) return;
+          if (isEligibleAttr(element, attr)) queue(attrTarget(element, attr));
+          return;
+        }
+
+        mutation.addedNodes.forEach((added) => {
+          collectTargets(added).forEach(queue);
+        });
+      });
+
+      if (pending.size === 0) return;
+
+      clearTimeout(flushTimeoutRef.current);
+      flushTimeoutRef.current = setTimeout(() => {
+        translateTargets(drain());
+      }, 150);
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: TRANSLATABLE_ATTRS,
+    });
+
+    return () => {
+      observer.disconnect();
+      clearTimeout(flushTimeoutRef.current);
+      pending.clear();
+    };
+  }, [translateTargets]);
+
+  return (
+    <div className="flex items-center gap-2">
+      <label htmlFor={langSelectId} className="sr-only">
+        Language
+      </label>
+      <select
+        id={langSelectId}
+        value={selectedLanguage}
+        onChange={(event) => setSharedLanguage(event.target.value)}
+        disabled={isTranslating}
+        // Each option is already written in the language it names, so this
+        // subtree must never be rewritten by our own pass.
+        translate="no"
+        className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-sm outline-none transition focus:border-sky-500 focus:ring-2 focus:ring-sky-200 disabled:cursor-not-allowed disabled:opacity-70"
+      >
+        {TRANSLATION_LANGUAGES.map((language) => (
+          <option key={language.code} value={language.code}>
+            {language.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/lib/locale/getServerLocale.js
+++ b/src/lib/locale/getServerLocale.js
@@ -1,0 +1,52 @@
+import { cache } from "react";
+import { cookies, headers } from "next/headers";
+
+const LOCALE_DETECT_ENDPOINT = `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/web/locale-detect`;
+
+// Tighter than TranslatorDropdown.js's client-side 2500ms budget for the same
+// lookup, since this one blocks the SSR response instead of running in the
+// background after paint.
+const SSR_LOCALE_DETECT_TIMEOUT_MS = 1200;
+
+// Mirrors TranslatorDropdown.js's own locale-code shape - loose on purpose (it
+// covers real codes like "mni-Mtei"), just enough to stop a malformed/tampered
+// cookie value from being echoed into a query string unescaped by
+// buildLocalizedUrl.
+const COOKIE_LOCALE_PATTERN = /^[a-zA-Z-]{1,10}$/;
+
+// Memoized per request via React's cache() so every Server Component that
+// needs the visitor's locale during the same render (layout, header, page)
+// collapses to a single /api/web/locale-detect call instead of one each.
+export const getServerLocale = cache(async function getServerLocale() {
+  // An explicit pick (made via TranslatorDropdown.js, which mirrors it into
+  // this same cookie name alongside localStorage) always wins over
+  // geolocation - including a stored "en", since that's still a real choice.
+  // Geolocation is only ever a fallback default for a visitor who hasn't
+  // picked anything yet.
+  const cookieStore = await cookies();
+  const cookieLocale = cookieStore.get("siteLanguage")?.value;
+  if (cookieLocale && COOKIE_LOCALE_PATTERN.test(cookieLocale)) return cookieLocale;
+
+  try {
+    const headersList = await headers();
+    // headers() reflects the incoming request to this Next.js server - it is
+    // not automatically forwarded to the outgoing fetch below.
+    const forwardedFor = headersList.get("x-forwarded-for") || "";
+
+    const response = await fetch(LOCALE_DETECT_ENDPOINT, {
+      headers: forwardedFor ? { "x-forwarded-for": forwardedFor } : {},
+      cache: "no-store",
+      signal: AbortSignal.timeout(SSR_LOCALE_DETECT_TIMEOUT_MS),
+    });
+
+    if (!response.ok) return "en";
+
+    const result = await response.json();
+    const locale = result?.data?.locale;
+    return typeof locale === "string" && locale ? locale : "en";
+  } catch {
+    // Timeout/abort, network failure, bad JSON - fail open to English rather
+    // than hold up the page render.
+    return "en";
+  }
+});

--- a/src/lib/locale/localizedUrl.js
+++ b/src/lib/locale/localizedUrl.js
@@ -1,0 +1,10 @@
+import { isSsrTranslatableLocale } from "./ssrSupportedLocales";
+
+// Appends `lang=<locale>` to a backend CMS URL so server/middlewares/translateMiddleware.js
+// returns (and Redis-caches) an already-translated response - letting Next.js SSR render
+// the page directly in the visitor's locale instead of translating the DOM after the fact.
+export function buildLocalizedUrl(url, locale) {
+  if (!locale || locale === "en" || !isSsrTranslatableLocale(locale)) return url;
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}lang=${locale}`;
+}

--- a/src/lib/locale/ssrSupportedLocales.js
+++ b/src/lib/locale/ssrSupportedLocales.js
@@ -1,0 +1,9 @@
+// Locales the backend's translateMiddleware.js (server/middlewares/translateMiddleware.js)
+// actually translates and caches for GET /api/web/* responses. Keep in sync with that
+// file's SUPPORTED_LOCALES - adding a locale here without a matching backend entry just
+// fragments the Next.js ISR cache with a `?lang=` variant identical to the English response.
+export const SSR_TRANSLATABLE_LOCALES = ["hi", "ta", "te", "mr", "gu", "bn", "kn", "ml"];
+
+export function isSsrTranslatableLocale(locale) {
+  return SSR_TRANSLATABLE_LOCALES.includes(locale);
+}


### PR DESCRIPTION
## Summary
- On a visitor's first page load (no `siteLanguage` cookie/localStorage yet),
  calls the backend's `GET /api/web/locale-detect` to resolve a default
  language from the visitor's IP-derived Indian state, and applies it
  automatically — both server-side (`getServerLocale.js`, so the first SSR
  render is already in the detected language) and client-side
  (`TranslatorDropdown.js`'s `detectAndApplyGeoLanguage`, as a fallback/sync
  path).
- Adds `buildLocalizedUrl` (`src/lib/locale/localizedUrl.js`), appending
  `?lang=<locale>` to CMS fetch URLs so `translateMiddleware.js` on the server
  returns pre-translated content — avoiding an English-then-translated flash
  on first paint. Wired into page-level data fetchers across the app
  (home, gold-loan, MSME, career, blog, CMS catch-all `[slug]`, etc.).
- `TranslatorDropdown.js` remains the manual override: a 21-language dropdown
  (English + 20 Eighth Schedule languages, excluding Bodo/Kashmiri which the
  translation provider doesn't support) that live-translates the DOM via
  `POST /api/translate`, with a `MutationObserver` to catch content mounted
  after the initial pass (modals, portals, route changes).
- An explicit dropdown pick always takes priority over the geo-detected
  default and is persisted to both `localStorage.siteLanguage` and a
  `siteLanguage` cookie (read by `getServerLocale.js` on subsequent SSR
  requests) so geolocation is never re-run once a language is known.

## Test plan
- [ ] Fresh browser profile + VPN/IP from a mapped state (e.g. Kerala) →
      confirm first paint renders in that language, not English-then-flash.
- [ ] Fresh profile from an unmapped state/country → confirm it defaults to
      English with no errors.
- [ ] Manually pick a language from the dropdown → confirm it overrides the
      geo default, persists across a refresh, and survives client-side
      navigation without reverting to English.
- [ ] Confirm dynamically mounted content (mega menu, modals) gets translated
      after opening, not just the initial page.
